### PR TITLE
Use GITHUB_TOKEN During Build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
       contents: read
       checks: write
       pull-requests: write
+      packages: write
 
     steps:
       - uses: actions/checkout@v2
@@ -47,7 +48,7 @@ jobs:
       - run: if [ -d "junit-tests" ]; then mkdir junit-tests; fi
         name: Prepare test outputs location
 
-      - run: "echo -e \"\n//npm.pkg.github.com/:_authToken=${{secrets.ACTION}}\" >> .npmrc"
+      - run: "echo -e \"\n//npm.pkg.github.com/:_authToken=${{secrets.GITHUB_TOKEN}}\" >> .npmrc"
 
       - run: yarn install --frozen-lockfile
         env:


### PR DESCRIPTION
## What does this change?

Moves the software to using the GITHUB_TOKEN secret during building.

## How can we measure success?

The software builds correctly using the GITHUB_TOKEN secret and no longer relies on Dave Allison's GitHub account.