### PR TITLE
Change Image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:mainline
+FROM nginx:mainline-alpine
 
 COPY startup.sh /
 COPY nginx-server.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
## What does this change?

Moves the base image to nginx:mainline-alpine to avoid problems identified by Snyk.

This was tested on a machine running macOS 12.6.8 under minikube 1.31.2 and on the dev. system.