### PR TITLE
Support for DELETE_USER Jobs

### DIFF
--- a/app/TypeFormatter.jsx
+++ b/app/TypeFormatter.jsx
@@ -55,6 +55,8 @@ class TypeFormatter extends React.Component {
         return "Export";
       case "COPY_FILE":
         return "Copy File";
+      case "DELETE_USER":
+        return "Delete User";
       default:
        return type;
     }

--- a/app/VidispineJobTool.jsx
+++ b/app/VidispineJobTool.jsx
@@ -434,6 +434,7 @@ class VidispineJobTool extends Component {
       { value: 'CONFORM', label: 'Conform', color: '#ffffff' },
       { value: 'COPY_FILE', label: 'Copy File', color: '#ffffff' },
       { value: 'DELETE_FILE', label: 'Delete File', color: '#ffffff' },
+      { value: 'DELETE_USER', label: 'Delete User', color: '#ffffff' },
       { value: 'ESSENCE_VERSION', label: 'Essence Version', color: '#ffffff' },
       { value: 'EXPORT', label: 'Export', color: '#ffffff' },
       { value: 'IMPORT', label: 'Import', color: '#ffffff' },


### PR DESCRIPTION
## What does this change?

Adds support for DELETE_USER jobs.

## How can we measure success?

DELETE_USER jobs now display correctly and can be found in the Type menu.

## Images

![PLT5](https://github.com/guardian/pluto-logtool/assets/10620802/ae12232d-064c-4775-8740-c967ac413371)

![PLT6](https://github.com/guardian/pluto-logtool/assets/10620802/b4b83cb5-0d10-4979-9839-42b494be721a)

This was tested on a machine running macOS 12.6.8 under minikube 1.31.2 and on the dev. system.
