### PR TITLE
High Light Syntax of JSON and XML Data.

### DIFF
--- a/app/DataInfoBox.jsx
+++ b/app/DataInfoBox.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import SyntaxHighlighter from 'react-syntax-highlighter';
+import { gradientDark } from 'react-syntax-highlighter/dist/esm/styles/hljs';
 
 class DataInfoBox extends React.Component {
 
@@ -12,9 +14,17 @@ render() {
     <div class="data_key">
       {this.props.dataData.key}
     </div>
-    <div class="data_value">
-      {this.props.dataData.value}
-    </div>
+    {this.props.dataData.value.substring(0,5) == "<?xml" ? (
+      <div class="data_value">
+        <SyntaxHighlighter language="xml" style={gradientDark} wrapLines="true" wrapLongLines="true">
+          {this.props.dataData.value}
+        </SyntaxHighlighter>
+      </div>
+    ) : (
+      <div class="data_value">
+        {this.props.dataData.value}
+      </div>
+    )}
   </div>
   }
 }

--- a/app/JobPage.jsx
+++ b/app/JobPage.jsx
@@ -14,6 +14,8 @@ import TypeFormatter from './TypeFormatter.jsx';
 import PriorityFormatter from './PriorityFormatter.jsx';
 import StepInfoBox from './StepInfoBox.jsx';
 import DataInfoBox from './DataInfoBox.jsx';
+import SyntaxHighlighter from 'react-syntax-highlighter';
+import { gradientDark } from 'react-syntax-highlighter/dist/esm/styles/hljs';
 
 class JobPage extends Component {
 
@@ -340,9 +342,9 @@ class JobPage extends Component {
           </div>
           <div class="job_page_json_box">
             <div class="job_page_json">
-              <pre class="job_page_json">
+              <SyntaxHighlighter language="json" style={gradientDark} wrapLines="true" wrapLongLines="true">
                 {JSON.stringify(this.state.vidispineData, null, 2)}
-              </pre>
+              </SyntaxHighlighter>
             </div>
           </div>
         </div>

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
     "react-select": "^3.1.0",
+    "react-syntax-highlighter": "^15.5.0",
     "reactjs-popup": "^2.0.4",
     "stream-browserify": "^3.0.0",
     "style-loader": "^2.0.0",


### PR DESCRIPTION
## What does this change?

Adds syntax high lighting to JSON and XML data.

## How can we measure success?

JSON and XML data gets its syntax high lighted.

## Images

![Screenshot 2024-07-18 at 12 59 26](https://github.com/user-attachments/assets/5bc61d88-c6c0-4032-8569-40ab0e57c87d)

![Screenshot 2024-07-18 at 12 59 46](https://github.com/user-attachments/assets/ad32c998-eefc-49ac-9432-68fc0e7df233)

This was tested on a machine running macOS 12.6.8 under minikube 1.31.2 and on the dev. system.