### PR TITLE
Format JSON

### DIFF
--- a/app/DataInfoBox.jsx
+++ b/app/DataInfoBox.jsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import SyntaxHighlighter from 'react-syntax-highlighter';
 import { gradientDark } from 'react-syntax-highlighter/dist/esm/styles/hljs';
 import beautify from "xml-beautifier";
+import JSONPretty from 'react-json-pretty';
+var JSONPretty1337 = require('react-json-pretty/dist/1337');
 
 class DataInfoBox extends React.Component {
 
@@ -15,17 +17,29 @@ render() {
     <div class="data_key">
       {this.props.dataData.key}
     </div>
-    {this.props.dataData.value.substring(0,5) == "<?xml" ? (
-      <div class="data_value">
-        <SyntaxHighlighter language="xml" style={gradientDark} wrapLines="true" wrapLongLines="true">
-          {beautify(this.props.dataData.value)}
-        </SyntaxHighlighter>
-      </div>
-    ) : (
-      <div class="data_value">
-        {this.props.dataData.value}
-      </div>
-    )}
+    {(() => {
+      if (this.props.dataData.value.substring(0,5) == "<?xml") {
+        return (
+          <div class="data_value">
+            <SyntaxHighlighter language="xml" style={gradientDark} wrapLines="true" wrapLongLines="true">
+              {beautify(this.props.dataData.value)}
+            </SyntaxHighlighter>
+          </div>
+        )
+      } else if ((this.props.dataData.key == "thumbnails") || (this.props.dataData.key == "storageMethodSelectionProgress")) {
+        return (
+          <div class="data_value">
+            <JSONPretty id="json-pretty" data={this.props.dataData.value} theme={JSONPretty1337}></JSONPretty>
+          </div>
+        )
+      } else {
+        return (
+          <div class="data_value">
+            {this.props.dataData.value}
+          </div>
+        )
+      }
+    })()}
   </div>
   }
 }

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "query-string": "^6.13.1",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
+    "react-json-pretty": "^2.2.0",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
     "react-select": "^3.1.0",


### PR DESCRIPTION
## What does this change?

Formats JSON.

## How can we measure success?

JSON is easier to read.

## Images

![PLT7](https://github.com/user-attachments/assets/d7936851-a5f5-4c3f-a112-73505e042c11)

This was tested on a machine running macOS 12.6.8 under minikube 1.31.2 and on the dev. system.